### PR TITLE
Improve comparison between linear subspaces

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -10,4 +10,5 @@
     Spinor <api_spinor>
     Co-representation <api_corep>
     Tensor <api_tensor>
+    Utility functions <api_utils>
 ```

--- a/docs/api/api_utils.md
+++ b/docs/api/api_utils.md
@@ -1,0 +1,5 @@
+# Utility functions
+
+```{eval-rst}
+    .. autofunction:: spgrep.utils.grassmann_distance
+```

--- a/docs/formulation/projection.md
+++ b/docs/formulation/projection.md
@@ -22,7 +22,7 @@ $$
         := \frac{ d_{\alpha} }{|G|} \sum_{ R \in G } \Delta^{ (\alpha) }(R)_{ij}^{\ast} R.
 $$
 Let $\phi^{(\alpha,j)}_{i} := P^{(\alpha)}_{ij} \phi$.
-Basis vectors $\{ \phi^{(\alpha,j)}_{i} \}_{i}` forms {math}`\Delta^{ (\alpha) }$.
+Basis vectors $\{ \phi^{(\alpha,j)}_{i} \}_{i}$ forms $\Delta^{ (\alpha) }$.
 
 $$
     P^{(\alpha)}_{ij} P^{(\alpha)}_{i'j'}

--- a/src/spgrep/representation.py
+++ b/src/spgrep/representation.py
@@ -184,6 +184,9 @@ def project_to_irrep(
                 if np.allclose(basis_nj, 0, atol=adjusted_atol):
                     continue
 
+                # Normalize basis vectors s.t. they are orthonormal.
+                basis_nj /= np.linalg.norm(basis_nj, axis=1)[:, None]
+
                 # Check if linearly independent with other basis vectors
                 # If basis_nj is not independent, Grassmann distance (min correlation) should be one.
                 # We use very rough tolerance, 0.5 to avoid numerical noises.

--- a/src/spgrep/representation.py
+++ b/src/spgrep/representation.py
@@ -185,10 +185,11 @@ def project_to_irrep(
                     continue
 
                 # Check if linearly independent with other basis vectors
-                if (len(basis) > 0) and (
-                    grassmann_distance(basis_nj, np.concatenate(np.array(basis), axis=0))
-                    < adjusted_atol
-                ):
+                # If basis_nj is not independent, Grassmann distance (min correlation) should be one.
+                # We use very rough tolerance, 0.5 to avoid numerical noises.
+                if (len(basis) > 0) and grassmann_distance(
+                    basis_nj, np.concatenate(np.array(basis), axis=0)
+                ) < 0.5:
                     continue
 
                 basis.append(basis_nj)

--- a/src/spgrep/representation.py
+++ b/src/spgrep/representation.py
@@ -11,7 +11,7 @@ from spgrep.utils import (
     NDArrayComplex,
     NDArrayFloat,
     NDArrayInt,
-    contain_space,
+    grassmann_distance,
     ndarray2d_to_integer_tuple,
 )
 
@@ -184,16 +184,11 @@ def project_to_irrep(
                 if np.allclose(basis_nj, 0, atol=adjusted_atol):
                     continue
 
-                # Them, normalize basis vectors s.t. they are orthonormal.
-                basis_nj /= np.linalg.norm(basis_nj, axis=1)[:, None]
-
                 # Check if linearly independent with other basis vectors
-                # Two subspaces spanned by orthonormal basis vectors V1 and V2 are the same if and only if
-                # triangular matrices R1 and R2 in QR decomposition of V1 and V2 are the same.
-                if len(basis) > 0 and contain_space(
-                    np.concatenate(basis, axis=0), basis_nj, atol=adjusted_atol
+                if (len(basis) > 0) and (
+                    grassmann_distance(basis_nj, np.concatenate(np.array(basis), axis=0))
+                    < adjusted_atol
                 ):
-                    # if any([contain_space(basis_nj, other, atol=adjusted_atol) for other in basis]):
                     continue
 
                 basis.append(basis_nj)
@@ -201,25 +196,29 @@ def project_to_irrep(
 
         return basis, count
 
-    adjusted_atol = atol
+    # Binary search for appropriate tolerance
+    atol_lb = 1e-10
+    atol_ub = 1e-2
+    adjusted_atol = np.clip(atol, atol_lb, atol_ub)
     for _ in range(max_num_trials):
         basis, count = _project_to_irrep(adjusted_atol)
         if count == num_basis:
             break
-        elif count > num_basis:
+        elif count < num_basis:
             # Tighten tolerance to compare basis vectors
-            adjusted_atol /= 2
-            print(count, num_basis, adjusted_atol)
+            adjusted_atol = np.sqrt(atol_lb * adjusted_atol)
+            warn(f"Tighten tolerance for projection: {adjusted_atol}")
         else:
             # Loosen tolerance to compare basis vectors
-            adjusted_atol *= 2
+            adjusted_atol = np.sqrt(atol_ub * adjusted_atol)
+            warn(f"Loosen tolerance for projection: {adjusted_atol}")
 
-    if count > num_basis:
+    if count < num_basis:
         warn(
             f"Inconsistent number of independent basis vectors (expect={num_basis}, actual={count})."
             "Try decreasing atol."
         )
-    elif count < num_basis:
+    elif count > num_basis:
         warn(
             f"Inconsistent number of independent basis vectors (expect={num_basis}, actual={count})."
             "Try increasing atol."

--- a/src/spgrep/tensor.py
+++ b/src/spgrep/tensor.py
@@ -106,10 +106,9 @@ def apply_intrinsic_symmetry(
         if (
             len(list_sym_basis) > 0
             and grassmann_distance(
-                sym_tensor.reshape(1, -1),
-                np.concatenate(list_sym_basis, axis=0),
+                sym_tensor.reshape(1, -1), np.concatenate(list_sym_basis, axis=0)
             )
-            < atol
+            < 0.5
         ):
             continue
 

--- a/src/spgrep/tensor.py
+++ b/src/spgrep/tensor.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from spgrep.irreps import enumerate_unitary_irreps, is_equivalent_irrep
 from spgrep.representation import get_character, get_direct_product, project_to_irrep
-from spgrep.utils import NDArrayComplex, NDArrayFloat, NDArrayInt, contain_space
+from spgrep.utils import NDArrayComplex, NDArrayFloat, NDArrayInt, grassmann_distance
 
 
 def get_symmetry_adapted_tensors(
@@ -81,7 +81,7 @@ def get_symmetry_adapted_tensors(
 
 def apply_intrinsic_symmetry(
     tensors: list[NDArrayComplex] | list[NDArrayFloat],
-    atol: float = 1e-8,
+    atol: float = 1e-6,  # A bit large tolerance setting to handle numerical noise
 ) -> list[NDArrayComplex] | list[NDArrayFloat]:
     """Apply symmetric group on tensors.
 
@@ -103,10 +103,13 @@ def apply_intrinsic_symmetry(
         sym_tensor /= np.linalg.norm(sym_tensor)
 
         # Store if independent to other symmetric tensors
-        if len(list_sym_basis) > 0 and contain_space(
-            np.concatenate(list_sym_basis, axis=0),
-            sym_tensor.reshape(1, -1),
-            atol=atol,
+        if (
+            len(list_sym_basis) > 0
+            and grassmann_distance(
+                sym_tensor.reshape(1, -1),
+                np.concatenate(list_sym_basis, axis=0),
+            )
+            < atol
         ):
             continue
 

--- a/src/spgrep/utils.py
+++ b/src/spgrep/utils.py
@@ -62,31 +62,47 @@ def nroot(z: np.complex_, n: int) -> np.complex_:
     return r * np.exp(1j * angle)
 
 
-def contain_space(
+def grassmann_distance(
     basis1: NDArrayComplex,
     basis2: NDArrayComplex,
-    atol: float = 1e-8,
-) -> bool:
-    """Return true if vector space spanned by ``basis2`` is contained in that by ``basis1``.
+) -> float:
+    r"""Return Grassmann distance between two linear subspaces spanned by ``basis1`` and ``basis2``.
 
-    That is, return True if any linear combination A[i, j] exists such that
-        basis2[j] == sum_{i} basis1[i] * A[i, j]
-    which is equivalent to ``A.T @ basis1 == basis2``.
+    References
+    * [1] Jihun Hamm and Daniel D. Lee. 2008. Grassmann discriminant analysis: a unifying view on subspace-based learning. In Proceedings of the 25th international conference on Machine learning (ICML '08). Association for Computing Machinery, New York, NY, USA, 376–383. https://doi.org/10.1145/1390156.1390204
+    * [2] Schubert Varieties and Distances between Subspaces of Different Dimensions, Ke Ye and Lek-Heng Lim, SIAM Journal on Matrix Analysis and Applications 2016 37:3, 1176-1197
 
     Parameters
     ----------
-    basis1: array, (dim_irrep, dim)
-    basis2: array, (dim_irrep, dim)
+    basis1: array, (k, n)
+        ``k``-dimensional subspace in :math:`\mathbb{C}^{n}`.
+        ``basis1[i]`` is the ``i``-th basis vector.
+    basis2: array, (l, n)
+        ``l``-dimensional subspace in :math:`\mathbb{C}^{n}`.
+        ``basis2[i]`` is the ``i``-th basis vector.
+
+    Returns
+    -------
+    distance: float
+        Min correlation of the two subspaces.
     """
-    if len(basis1) == 0:
-        return False  # basis1 is empty
+    # Orthonormal bases
+    # QR decomposition of column-wise vectors gives Gram-Schmidt orthonormalized vectors in column wise.
+    col_orthonormal_basis1 = np.linalg.qr(np.transpose(basis1))[0]
+    col_orthonormal_basis2 = np.linalg.qr(np.transpose(basis2))[0]
 
-    # Solve basis1.T @ A = basis2.T
-    A, residual, _, _ = np.linalg.lstsq(basis1.T, basis2.T, rcond=None)
+    # Singular values in descending order
+    canonical_correlations = np.linalg.svd(
+        np.conj(col_orthonormal_basis1.T) @ col_orthonormal_basis2, compute_uv=False
+    )
 
-    # Always compare vectors by L_infinity norm
-    basis2_T_near = basis1.T @ A
-    return np.allclose(basis2_T_near, basis2.T, atol=atol)
+    # Averaged projection metric
+    dim = min(basis1.shape[0], basis2.shape[0])
+    distance = np.sqrt(
+        np.mean(np.arccos(np.clip(canonical_correlations[:dim], a_min=-1, a_max=1)) ** 2)
+    )
+
+    return distance
 
 
 def mode_dot(coeffs: NDArray, list_matrix: list[NDArray]) -> NDArray:

--- a/src/spgrep/utils.py
+++ b/src/spgrep/utils.py
@@ -66,6 +66,7 @@ def grassmann_distance(
     basis1: NDArrayComplex,
     basis2: NDArrayComplex,
     ord: Literal["min", "projection"] = "min",
+    skip_orthonormalization: bool = False,
 ) -> float:
     r"""Return Grassmann distance between two linear subspaces spanned by ``basis1`` and ``basis2``.
 
@@ -85,15 +86,21 @@ def grassmann_distance(
         Kind of Grassmann distance to be calculated
         * ``ord='min'``: Min correlation
         * ``ord='projection'``: Projection metric
+    skip_orthonormalization: bool default=False
+        If true, skip to orthonormalize bases.
 
     Returns
     -------
     distance: float
     """
     # Orthonormal bases
-    # QR decomposition of column-wise vectors gives Gram-Schmidt orthonormalized vectors in column wise.
-    col_orthonormal_basis1 = np.linalg.qr(np.transpose(basis1))[0]
-    col_orthonormal_basis2 = np.linalg.qr(np.transpose(basis2))[0]
+    if skip_orthonormalization:
+        col_orthonormal_basis1 = basis1.T
+        col_orthonormal_basis2 = basis2.T
+    else:
+        # QR decomposition of column-wise vectors gives Gram-Schmidt orthonormalized vectors in column wise.
+        col_orthonormal_basis1 = np.linalg.qr(np.transpose(basis1))[0]
+        col_orthonormal_basis2 = np.linalg.qr(np.transpose(basis2))[0]
 
     # Singular values in descending order
     canonical_correlations = np.linalg.svd(

--- a/tests/test_representation.py
+++ b/tests/test_representation.py
@@ -51,6 +51,9 @@ def test_project_to_irrep(C3v):
         projected = project_to_irrep(reg, irrep)
         count += len(projected)
 
+        for basis in projected:
+            assert np.allclose(np.linalg.norm(basis, axis=1), 1)
+
     assert count == sum(irrep.shape[1] for irrep in irreps)
 
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -105,8 +105,7 @@ def test_symmetric_tensor(hall_number, rank, num_expect):
     rotations = symmetry["rotations"]
 
     rep = get_representation_on_symmetric_matrix(rotations)
-    atol = 1e-8
-    tensors = get_symmetry_adapted_tensors(rep, rotations, rank, real=True, atol=atol)
-    sym_tensors = apply_intrinsic_symmetry(tensors, atol=atol)
+    tensors = get_symmetry_adapted_tensors(rep, rotations, rank, real=True)
+    sym_tensors = apply_intrinsic_symmetry(tensors, atol=1e-4)
 
     assert len(sym_tensors) == num_expect

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -97,7 +97,6 @@ def get_representation_on_symmetric_matrix(rotations: np.ndarray) -> np.ndarray:
         (485, 1, 2),
         (485, 2, 5),
         (485, 3, 10),
-        # (485, 4, 18),  # TODO
     ],
 )
 def test_symmetric_tensor(hall_number, rank, num_expect):
@@ -106,6 +105,18 @@ def test_symmetric_tensor(hall_number, rank, num_expect):
 
     rep = get_representation_on_symmetric_matrix(rotations)
     tensors = get_symmetry_adapted_tensors(rep, rotations, rank, real=True)
-    sym_tensors = apply_intrinsic_symmetry(tensors, atol=1e-4)
+    sym_tensors = apply_intrinsic_symmetry(tensors)
 
     assert len(sym_tensors) == num_expect
+
+
+@pytest.mark.skip()
+def test_symmetric_tensor_hexagonal_rank4():
+    symmetry = get_symmetry_from_database(hall_number=485)
+    rotations = symmetry["rotations"]
+
+    rep = get_representation_on_symmetric_matrix(rotations)
+    tensors = get_symmetry_adapted_tensors(rep, rotations, rank=4, real=True)
+    sym_tensors = apply_intrinsic_symmetry(tensors)
+
+    assert len(sym_tensors) == 18

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from spgrep.utils import (
-    contain_space,
+    grassmann_distance,
     is_integer_array,
     is_prime,
     mode_dot,
@@ -39,35 +39,60 @@ def test_nroot():
     assert np.allclose(actual, expect)
 
 
-def test_contain_space():
-    # Strictly contained
-    assert contain_space(
-        np.array([[1, 0, 0], [0, 1, 0]]),
-        np.array([[1, 1, 0]]),
+def test_grassmann_distance():
+    assert (
+        grassmann_distance(
+            np.array(
+                [
+                    [1, 0, 0],
+                    [0, 1j, 0],
+                ]
+            ),
+            np.array(
+                [
+                    [0, 1, 0],
+                    [0, 0, 1],
+                ]
+            ),
+        )
+        > 0
     )
 
-    # Equal case
-    assert contain_space(
-        np.array([[1, 0, 0], [0, 1, 0]]),
-        np.array([[1, 1, 0], [1, -1, 0]]),
+    assert np.isclose(
+        grassmann_distance(
+            np.array(
+                [
+                    [2, 0, 0],
+                    [0, 4j, 0],
+                ]
+            ),
+            np.array(
+                [
+                    [1, 1j, 0],
+                    [8, 0, 0],
+                ]
+            ),
+        ),
+        0,
+        atol=1e-5,
     )
 
-    # False cases
-    assert not contain_space(
-        np.array([]),
-        np.array([[1, 0, 1]]),
-    )
-    assert not contain_space(
-        np.array([[1, 0, 0], [0, 1, 0]]),
-        np.array([[1, 0, 1]]),
-    )
-    assert not contain_space(
-        np.array([[1, 0, 0], [0, 1, 0]]),
-        np.array([[1, 0, 0], [0, 0, 1]]),
-    )
-    assert not contain_space(
-        np.array([[1, 0, 0], [0, 1, 0]]),
-        np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+    assert np.isclose(
+        grassmann_distance(
+            np.array(
+                [
+                    [1, 1j, 0],
+                ]
+            ),
+            np.array(
+                [
+                    [0, 1, 0],
+                    [1, 0, 0],
+                ]
+            ),
+        ),
+        0,
+        atol=1e-5,
     )
 
 


### PR DESCRIPTION
Use Grassmann distance to compare two linear subspaces spanned by symmetry-adapted bases.