### PR TITLE
Fix docutils and sphinx versions not to collapse documents

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,10 @@ EXTRAS = {
         "ipykernel",
     ],
     "docs": [
-        "sphinx",
+        # We cannot update sphinx to >6 until docutils==0.20 is released: https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/322
+        # Another issue requires sphinx<4.3 (fixed in pydata-sphinx-theme>=0.8.0): https://github.com/pydata/pydata-sphinx-theme/pull/509
+        "docutils<=0.17",
+        "sphinx<4.3",
         "sphinx-autobuild",
         "nbsphinx",
         "sphinxcontrib-bibtex",


### PR DESCRIPTION
`docutils>=0.18,<0.20` causes incompatibility with sphinx-bibtex like the following screenshot

<img width="842" alt="image" src="https://user-images.githubusercontent.com/7272505/229332954-4dcdcd9a-40d2-4098-ba53-2d1742bd0955.png">

We downgrade docutils for now.