### PR TITLE
ci: add path filter and pass gate to testing workflow

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -1,0 +1,14 @@
+python:
+  - 'spgrep/**'
+  - 'tests/**'
+  - 'pyproject.toml'
+  - 'uv.lock'
+  - '.github/workflows/testing.yml'
+  - '.github/filters.yaml'
+docs:
+  - 'docs/**'
+  - 'spgrep/**'
+  - 'pyproject.toml'
+  - 'uv.lock'
+  - '.github/workflows/testing.yml'
+  - '.github/filters.yaml'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,7 +10,22 @@ env:
   PYTHON_VERSION: "3.13"
 
 jobs:
+  path-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: .github/filters.yaml
+
   tests:
+    needs: path-filter
+    if: ${{ needs.path-filter.outputs.python == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -39,6 +54,8 @@ jobs:
         fail_ci_if_error: false
 
   docs:
+    needs: path-filter
+    if: ${{ needs.path-filter.outputs.docs == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -66,3 +83,14 @@ jobs:
       with:
         deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         publish_dir: ./docs_build
+
+  pass:
+    if: always()
+    name: ✅ Pass tests
+    needs: [tests, docs]
+    runs-on: ubuntu-latest
+    steps:
+      - if: needs.tests.result == 'failure'
+        run: exit 1
+      - if: needs.docs.result == 'failure'
+        run: exit 1


### PR DESCRIPTION
## Summary
- Add `.github/filters.yaml` with `python` and `docs` path groups (source, tests, pyproject, uv.lock, and the workflow/filter files themselves).
- Introduce a `path-filter` job in `.github/workflows/testing.yml` that runs `dorny/paths-filter@v4` and gates the existing `tests` and `docs` jobs via `if: needs.path-filter.outputs.<group> == 'true'`.
- Add a final `pass` aggregation job (`if: always()`, `needs: [tests, docs]`) that fails only when an upstream job actually failed, so it stays green when jobs are skipped by the filter -- matching the pattern used in [`spglib/moyo`'s `tests.yaml`](https://github.com/spglib/moyo/blob/main/.github/workflows/tests.yaml).

## Test plan
- [x] Workflow syntax validated locally (`prek run --files .github/workflows/testing.yml .github/filters.yaml` -- all hooks including the GitHub Workflow validator pass).
- [ ] On this PR: confirm `path-filter` runs, that `tests` and `docs` are triggered since workflow/filter files themselves changed, and that `pass` reports success.
- [ ] On a follow-up docs-only PR: confirm `tests` is skipped while `docs` runs, and the `pass` check is still green.
- [ ] Update any branch protection rule that currently required `tests` or `docs` to instead require the new `Pass tests` check (done outside this PR).

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
