### PR TITLE
fix: coerce kpoint to ndarray in public APIs

### DIFF
--- a/src/spgrep/core.py
+++ b/src/spgrep/core.py
@@ -89,6 +89,7 @@ def get_spacegroup_irreps(
         Let ``i = mapping_little_group[idx]``.
         ``(rotations[i], translations[i])`` belongs to the little group of given space space group and kpoint.
     """
+    kpoint = np.asarray(kpoint, dtype=float)
     # Transform given `kpoint` in dual of `lattice`
     dual_lattice = np.linalg.inv(lattice).T
     if reciprocal_lattice is None:
@@ -192,6 +193,8 @@ def get_spacegroup_irreps_from_primitive_symmetry(
         Let ``i = mapping_little_group[idx]``.
         ``(rotations[i], translations[i])`` belongs to the little group of given space space group and kpoint.
     """
+    kpoint = np.asarray(kpoint, dtype=float)
+
     # Sanity check to use primitive cell
     for rotation, translation in zip(rotations, translations):
         if np.allclose(rotation, np.eye(3), rtol=rtol, atol=atol) and not np.allclose(
@@ -315,6 +318,8 @@ def get_magnetic_spacegroup_coreps_from_primitive_symmetry(
         Let ``i = mapping_little_group[idx]``.
         ``(rotations[i], translations[i])`` belongs to the little group of given space space group and kpoint.
     """
+    kpoint = np.asarray(kpoint, dtype=float)
+
     # Sanity check to use primitive cell
     for rotation, translation, time_reversal in zip(rotations, translations, time_reversals):
         if (
@@ -442,6 +447,8 @@ def get_spacegroup_spinor_irreps(
     """
     if kpoint is None:
         kpoint = np.zeros(3)
+    else:
+        kpoint = np.asarray(kpoint, dtype=float)
 
     # Transform given `kpoint` in dual of `lattice`
     dual_lattice = np.linalg.inv(lattice).T
@@ -616,6 +623,8 @@ def get_spacegroup_spinor_irreps_from_primitive_symmetry(
     """
     if kpoint is None:
         kpoint = np.zeros(3)
+    else:
+        kpoint = np.asarray(kpoint, dtype=float)
 
     # Sanity check to use primitive cell
     for rotation, translation in zip(rotations, translations):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+import spglib
 
 from spgrep.core import (
     get_crystallographic_pointgroup_irreps_from_symmetry,
@@ -146,3 +147,21 @@ def test_get_spacegroup_irreps(method, kpoint, shape_expect, num_sym_expect, cor
         assert is_unitary(irrep)
 
     assert is_unique_irreps(irreps)
+
+
+def test_kpoint_list_input_regression():
+    # Regression for https://github.com/spglib/spgrep/issues/284
+    # Passing kpoint as a Python list previously triggered list-concatenation
+    # in `2 * kpoint` and produced doubled real irreps.
+    symmetry = spglib.get_symmetry_from_database(517)  # Pm-3m (No. 221)
+    rotations = symmetry["rotations"]
+    translations = symmetry["translations"]
+    kpoint = [0.5, 0.5, 0.5]
+
+    irreps_list, _ = get_spacegroup_irreps_from_primitive_symmetry(
+        rotations, translations, kpoint, real=True
+    )
+    irreps_arr, _ = get_spacegroup_irreps_from_primitive_symmetry(
+        rotations, translations, np.asarray(kpoint, dtype=float), real=True
+    )
+    assert [ir.shape for ir in irreps_list] == [ir.shape for ir in irreps_arr]


### PR DESCRIPTION
## Summary

- Python list inputs to `get_spacegroup_irreps_from_primitive_symmetry` (and the other kpoint-taking public APIs) were silently misinterpreted inside `enumerate_small_representations`: the line `two_kpoint = 2 * kpoint` concatenates a list instead of scaling element-wise, which forced the Frobenius-Schur indicator to 0 and doubled the dimensions of returned physically irreducible representations.
- Coerce `kpoint` with `np.asarray(..., dtype=float)` at the public API boundaries (`get_spacegroup_irreps`, `get_spacegroup_irreps_from_primitive_symmetry`, `get_magnetic_spacegroup_coreps_from_primitive_symmetry`, `get_spacegroup_spinor_irreps`, `get_spacegroup_spinor_irreps_from_primitive_symmetry`) so list and ndarray inputs produce identical results.
- Add a regression test covering the exact reproducer from #284.

Fixes the first bullet of #284. The second bullet (physical little group should include operations that send k -> -k for non-TR-invariant k) is left to a follow-up issue, since it is a substantive API-contract change.

## Test plan

- [x] `uv run pytest -q` (130 passed, 1 skipped)
- [x] `uv run pytest tests/test_core.py::test_kpoint_list_input_regression -v`
- [x] `prek run --files src/spgrep/core.py tests/test_core.py` (ruff, mypy, etc. pass)
- [x] Manual reproducer from #284: list and ndarray kpoint inputs now return identical irrep shapes `[(48,1,1)x4, (48,2,2)x2, (48,3,3)x4]` at Pm-3m, k=[0.5,0.5,0.5].

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
