### PR TITLE
fix: conjugate right operand in co-rep a0.u construction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ prek run --all-files                                              # lint + forma
 
 CI (`.github/workflows/testing.yml`) runs the matrix over Python 3.10/3.11/3.12/3.13 and a separate docs build job; pandoc is required for docs builds.
 
-Releases are tag-driven: bump `docs/changelog.md`, then `git tag <version> && git push origin <version>`. Version is derived by `setuptools-scm`.
+Releases are tag-driven: move `[Unreleased]` entries under a dated `## vX.Y.Z` heading in `docs/changelog.md`, then `git tag <version> && git push origin <version>`. Version is derived by `setuptools-scm`.
 
 ## Architecture
 
@@ -92,3 +92,5 @@ Tests in `tests/` mirror the source layout (`tests/rep/`, `tests/symmetry/`, top
 - The `_constants.MAX_NUM_RANDOM_GENERATIONS` retry knob exists because the `"random"` method can statistically fail; honor it rather than introducing infinite loops.
 - Ruff is configured with `line-length = 99` and selects `E`, `F`, `I`, `UP`. `D2xx` pydocstyle rules listed in `[tool.ruff.lint.extend-ignore]` are intentionally disabled — do not re-enable them piecemeal.
 - mypy excludes `docs/` and sets `warn_no_return = false`.
+- `docs/changelog.md` follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/). User-visible changes go under `## [Unreleased]` in a categorized subsection (`### Added`, `### Changed`, `### Deprecated`, `### Removed`, `### Fixed`, `### Security`); the section is dated and renamed at release time. Historical `v0.x` entries predate the format and are left as flat bullet lists.
+- Co-representation conventions (`src/spgrep/corep.py`, `docs/formulation/irreps/corep.md`): for `a ∈ Da_0` anti-linear, the multiplication law is `Γ(a) · Γ(u)^* = ω(a,u) · Γ(a·u)`. When constructing the extension from a unitary irrep `Γ` of `D` to a co-rep of `M`, the right operand must be complex-conjugated (`@ np.conj(...)`). Factor systems spgrep builds have `|ω| = 1`, so `1/ω = conj(ω)` — the prefactor `np.conj(factor_system[a0_idx, xsg_indices])` depends on this.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Fix co-representation extension formula for `a_0 u` in all three Frobenius-Schur cases: the right operand is now complex-conjugated as required by the co-representation multiplication law. Prior output violated the law for any source irrep with non-real matrices.
+
 ## v0.5.0 (19 Jan. 2026)
 
 - The following modules are separated into subpackages: `spgrep.group`, `spgrep.representation`, `spgrep.pointgroup`, `spgrep.irreps`, `spgrep.tensor`, and `spgrep.transform`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,15 @@
 # Change Log
 
-## Unreleased
+All notable changes to this project will be documented in this file.
 
-- Fix co-representation extension formula for `a_0 u` in all three Frobenius-Schur cases: the right operand is now complex-conjugated as required by the co-representation multiplication law. Prior output violated the law for any source irrep with non-real matrices.
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Co-representation extension formula for `a_0 u` in all three Frobenius-Schur cases (`_enumerate_small_corepresentations_with_factor_system` in `spgrep.corep`): the right operand is now complex-conjugated as required by the co-representation multiplication law. The previous output violated the law whenever the source irrep of the unitary subgroup had non-real matrices. `enumerate_spinor_small_corepresentations` inherits the fix since it delegates to the same helper.
 
 ## v0.5.0 (19 Jan. 2026)
 

--- a/docs/formulation/irreps/corep.md
+++ b/docs/formulation/irreps/corep.md
@@ -72,7 +72,7 @@ A new basis $\{ \frac{1}{\sqrt{2}}(\phi_{i} + \psi_{i}) \}_{i}$ gives the follow
 $$
     \tilde{\mathbf{\Gamma}}(u) &= \mathbf{\Gamma}(u) \\
     \tilde{\mathbf{\Gamma}}(a_{0}) &= \mathbf{U} \\
-    \tilde{\mathbf{\Gamma}}(a_{0}u) &= \omega(a_{0}, u)^{\ast} \tilde{\mathbf{\Gamma}}(a_{0}) \tilde{\mathbf{\Gamma}}(u) \\
+    \tilde{\mathbf{\Gamma}}(a_{0}u) &= \omega(a_{0}, u)^{\ast} \tilde{\mathbf{\Gamma}}(a_{0}) \tilde{\mathbf{\Gamma}}(u)^{\ast} \\
     \mathbf{U}\mathbf{U}^{\ast} &= \omega(a_{0}, a_{0})\Gamma(a_{0}^{2}).
 $$
 
@@ -105,7 +105,7 @@ $$
             \mathbf{0} & -\mathbf{U} \\
             \mathbf{U} & \mathbf{0} \\
         \end{pmatrix} \\
-    \tilde{\mathbf{\Gamma}}(a_{0}u) &= \omega(a_{0}, u)^{\ast} \tilde{\mathbf{\Gamma}}(a_{0}) \tilde{\mathbf{\Gamma}}(u)
+    \tilde{\mathbf{\Gamma}}(a_{0}u) &= \omega(a_{0}, u)^{\ast} \tilde{\mathbf{\Gamma}}(a_{0}) \tilde{\mathbf{\Gamma}}(u)^{\ast}
 $$
 
 ### Case: $\xi^{\alpha} = 0$
@@ -123,7 +123,7 @@ $$
             \mathbf{0} & \omega(a_{0}, a_{0}) \mathbf{\Gamma}(a_{0}^{2}) \\
             \mathbf{1} & \mathbf{0} \\
         \end{pmatrix} \\
-    \tilde{\mathbf{\Gamma}}(a_{0}u) &= \omega(a_{0}, u)^{\ast} \tilde{\mathbf{\Gamma}}(a_{0}) \tilde{\mathbf{\Gamma}}(u)
+    \tilde{\mathbf{\Gamma}}(a_{0}u) &= \omega(a_{0}, u)^{\ast} \tilde{\mathbf{\Gamma}}(a_{0}) \tilde{\mathbf{\Gamma}}(u)^{\ast}
 $$
 
 (corep_spinor_factor_system)=

--- a/src/spgrep/corep.py
+++ b/src/spgrep/corep.py
@@ -382,7 +382,9 @@ def _enumerate_small_corepresentations_with_factor_system(
             corep = np.zeros((order, dim, dim), dtype=np.complex128)
             corep[xsg_indices] = irrep
             corep[a0u] = (
-                np.conj(factor_system[a0_idx, xsg_indices])[:, None, None] * U[None, :, :] @ irrep
+                np.conj(factor_system[a0_idx, xsg_indices])[:, None, None]
+                * U[None, :, :]
+                @ np.conj(irrep)
             )
         elif indicator == -1:
             U = get_intertwiner(irrep, conj_irrep, atol, max_num_random_generations)
@@ -402,7 +404,7 @@ def _enumerate_small_corepresentations_with_factor_system(
             corep[a0u] = (
                 np.conj(factor_system[a0_idx, xsg_indices])[:, None, None]
                 * corep_a0[None, :, :]
-                @ corep[xsg_indices]
+                @ np.conj(corep[xsg_indices])
             )
         elif indicator == 0:
             corep = np.zeros((order, 2 * dim, 2 * dim), dtype=np.complex128)
@@ -423,7 +425,7 @@ def _enumerate_small_corepresentations_with_factor_system(
             corep[a0u] = (
                 np.conj(factor_system[a0_idx, xsg_indices])[:, None, None]
                 * corep_a0[None, :, :]
-                @ corep[xsg_indices]
+                @ np.conj(corep[xsg_indices])
             )
         else:
             raise ValueError("Unreachable!")

--- a/tests/test_corep.py
+++ b/tests/test_corep.py
@@ -5,9 +5,35 @@ from spgrep.core import (
     get_crystallographic_pointgroup_spinor_irreps_from_symmetry,
     get_magnetic_spacegroup_coreps_from_primitive_symmetry,
 )
-from spgrep.corep import get_corep_spinor_factor_system
-from spgrep.symmetry.group import get_cayley_table
-from spgrep.utils import NDArrayComplex, NDArrayFloat, NDArrayInt
+from spgrep.corep import (
+    _enumerate_small_corepresentations_with_factor_system,
+    get_corep_spinor_factor_system,
+)
+from spgrep.symmetry.group import get_cayley_table, get_factor_system_from_little_group
+from spgrep.utils import (
+    NDArrayBool,
+    NDArrayComplex,
+    NDArrayFloat,
+    NDArrayInt,
+    get_symmetry_from_hall_number,
+)
+
+
+def _assert_corep_composition_law(
+    corep: NDArrayComplex,
+    anti_linear: NDArrayBool,
+    factor_system: NDArrayComplex,
+    table: NDArrayInt,
+    atol: float = 1e-8,
+) -> None:
+    """Verify ``D(g_i) @ (D(g_j)* if g_i anti-linear else D(g_j)) == omega(g_i, g_j) * D(g_i g_j)``."""
+    order = corep.shape[0]
+    for i in range(order):
+        for j in range(order):
+            right = np.conj(corep[j]) if anti_linear[i] else corep[j]
+            lhs = corep[i] @ right
+            rhs = factor_system[i, j] * corep[table[i, j]]
+            assert np.allclose(lhs, rhs, atol=atol), f"corep law violated at (i={i}, j={j})"
 
 
 def check_corep_cocycle_condition(
@@ -96,6 +122,10 @@ def test_get_crystallographic_pointgroup_spinor_irreps_from_symmetry(
         method=method,
     )
 
+    table = get_cayley_table(rotations, time_reversals)
+    for co_irrep in co_irreps:
+        _assert_corep_composition_law(co_irrep, anti_linear, factor_system, table)
+
 
 @pytest.mark.parametrize(
     "kpoint",
@@ -135,3 +165,57 @@ def test_get_magnetic_spacegroup_coreps_from_primitive_symmetry(
         kpoint=kpoint,
         method=method,
     )
+
+
+def test_corep_composition_law_pm3m_lambda():
+    """Regression: co-rep extension must conjugate the right operand when the left is anti-linear.
+
+    Constructs the little group of :math:`\\pm \\mathbf{k}` for Pm-3m at
+    :math:`\\mathbf{k} = (1/4, 1/4, 1/4)` (a non-TRIM point; the 2-dim ``E`` irrep
+    of :math:`D_3` appears here and is non-real). Feeds the k-flip mask as
+    ``little_time_reversals`` -- this matches how the co-rep machinery is used to
+    extend a small rep of :math:`G^{\\mathbf{k}}` to :math:`G^{\\mathbf{k}\\bar{\\mathbf{k}}}`.
+    Before the conjugation fix this assertion fails at 72/144 pairs for one of
+    the three ``ksi`` blocks; after the fix all pairs pass.
+    """
+    rotations, translations = get_symmetry_from_hall_number(517)  # Pm-3m
+    kpoint = np.array([0.25, 0.25, 0.25])
+
+    pm_k_mask = []
+    flip_k_list = []
+    for rot in rotations:
+        residual_plus = rot.T @ kpoint - kpoint
+        residual_minus = rot.T @ kpoint + kpoint
+        keeps_k = np.allclose(residual_plus - np.rint(residual_plus), 0)
+        flips_k = np.allclose(residual_minus - np.rint(residual_minus), 0)
+        if keeps_k:
+            pm_k_mask.append(True)
+            flip_k_list.append(0)
+        elif flips_k:
+            pm_k_mask.append(True)
+            flip_k_list.append(1)
+        else:
+            pm_k_mask.append(False)
+    pm_k_mask = np.array(pm_k_mask)
+    flip_k = np.array(flip_k_list, dtype=int)
+    pm_k_rotations = rotations[pm_k_mask]
+    pm_k_translations = translations[pm_k_mask]
+
+    factor_system = get_factor_system_from_little_group(pm_k_rotations, pm_k_translations, kpoint)
+    table = get_cayley_table(pm_k_rotations, flip_k)
+
+    coreps, _ = _enumerate_small_corepresentations_with_factor_system(
+        little_rotations=pm_k_rotations,
+        little_translations=pm_k_translations,
+        little_time_reversals=flip_k,
+        kpoint=kpoint,
+        factor_system=factor_system,
+    )
+
+    # Translation phases carried on the small co-reps -- strip them so the
+    # residual composition law uses the linear-part factor system directly.
+    phases = np.exp(-2j * np.pi * pm_k_translations @ kpoint)
+    anti_linear = flip_k.astype(bool)
+    for corep in coreps:
+        bare = corep / phases[:, None, None]
+        _assert_corep_composition_law(bare, anti_linear, factor_system, table)

--- a/tests/test_corep.py
+++ b/tests/test_corep.py
@@ -167,18 +167,19 @@ def test_get_magnetic_spacegroup_coreps_from_primitive_symmetry(
     )
 
 
-def test_corep_composition_law_pm3m_lambda():
+def test_corep_composition_law_221_lambda():
     """Regression: co-rep extension must conjugate the right operand when the left is anti-linear.
 
-    Constructs the little group of :math:`\\pm \\mathbf{k}` for Pm-3m at
-    :math:`\\mathbf{k} = (1/4, 1/4, 1/4)` (a non-TRIM point; the 2-dim ``E`` irrep
-    of :math:`D_3` appears here and is non-real). Feeds the k-flip mask as
-    ``little_time_reversals`` -- this matches how the co-rep machinery is used to
-    extend a small rep of :math:`G^{\\mathbf{k}}` to :math:`G^{\\mathbf{k}\\bar{\\mathbf{k}}}`.
-    Before the conjugation fix this assertion fails at 72/144 pairs for one of
-    the three ``ksi`` blocks; after the fix all pairs pass.
+    Constructs the little group of :math:`\\pm \\mathbf{k}` for ITA No. 221
+    (:math:`Pm\\bar{3}m`) at :math:`\\mathbf{k} = (1/4, 1/4, 1/4)` (a non-TRIM
+    point; the 2-dim ``E`` irrep of :math:`D_3` appears here and is non-real).
+    Feeds the k-flip mask as ``little_time_reversals`` -- this matches how the
+    co-rep machinery is used to extend a small rep of :math:`G^{\\mathbf{k}}` to
+    :math:`G^{\\mathbf{k}\\bar{\\mathbf{k}}}`. Before the conjugation fix this
+    assertion fails at 72/144 pairs for one of the three ``ksi`` blocks; after
+    the fix all pairs pass.
     """
-    rotations, translations = get_symmetry_from_hall_number(517)  # Pm-3m
+    rotations, translations = get_symmetry_from_hall_number(517)  # ITA No. 221, Pm-3m
     kpoint = np.array([0.25, 0.25, 0.25])
 
     pm_k_mask = []


### PR DESCRIPTION
## Summary

- Fix a bug in all three ξ ∈ {+1, −1, 0} branches of `_enumerate_small_corepresentations_with_factor_system`: the right operand was applied without complex conjugation, violating the co-rep multiplication law `Γ(a) · Γ(u)^* = ω(a, u) · Γ(a · u)` whenever the unitary-subgroup irrep `Γ(u)` has non-real entries. Solving for `Γ(a · u)` with `|ω| = 1` (unit-modulus for every factor system spgrep builds) gives `conj(ω(a, u)) · U · conj(Γ(u))`. `enumerate_spinor_small_corepresentations` reuses this helper, so the same bug affected the spinor path.
- Sync `docs/formulation/irreps/corep.md` by adding `^*` on `Γ̃(u)` in each `Γ̃(a₀u)` formula.
- Add regression coverage: the existing corep tests never asserted the co-rep multiplication law on their outputs, and every pre-existing fixture happened to produce real `Γ(u)` matrices (so `conj(Γ(u)) = Γ(u)` masked the error). A dedicated test on SG 221 Pm-3m at `k = (1/4, 1/4, 1/4)` -- where the 2-dim `E` irrep of `D₃` appears and is non-real -- reproduces the bug (72/144 pairs fail before the fix). The spinor co-rep test is also extended to assert the multiplication law on every co-irrep it produces.

## Test plan

- [x] `uv run pytest tests/test_corep.py` -- new regression passes; extended spinor test still passes.
- [x] `uv run pytest tests/` -- full suite (132 passed, 1 skipped).
- [x] `prek run --files src/spgrep/corep.py tests/test_corep.py docs/formulation/irreps/corep.md` -- ruff / mypy / format clean.
- [ ] CI green (GitHub Actions).
- [ ] Docs build (`uv run sphinx-build docs docs_build`) shows no new warnings.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
