### PR TITLE
chore: pin uv resolver to one-week-old index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
   "spglib>=2.7",
   "typing-extensions",
 ]
-
 optional-dependencies.dev = [
   "ipykernel",
   "ipython",
@@ -67,12 +66,15 @@ urls.homepage = "https://github.com/spglib/spgrep"
 
 [tool.setuptools_scm]
 
+[tool.uv]
+exclude-newer = "1 week"
+
 [tool.ruff]
 line-length = 99
 lint.extend-select = [
-  "E", # pycodestyle-errors
-  "F", # pyflakes
-  "I", # isort
+  "E",  # pycodestyle-errors
+  "F",  # pyflakes
+  "I",  # isort
   # "D",           # pydocstyle
   "UP", # pyupgrade
 ]
@@ -87,11 +89,11 @@ lint.extend-ignore = [
   "E501",
 ]
 
-[tool.pytest.ini_options]
-testpaths = [ "tests" ]
-
 [tool.mypy]
 exclude = [
-  'docs',
+  "docs",
 ]
 warn_no_return = false
+
+[tool.pytest]
+ini_options.testpaths = [ "tests" ]

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-04-13T23:13:57.213018Z"
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"
@@ -2143,11 +2147,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
 ]
 
 [[package]]
@@ -2308,7 +2312,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Pin `[tool.uv] exclude-newer = "1 week"` so lockfile resolution ignores packages released in the last week, avoiding breakage from freshly published releases that have not yet been vetted.
- `uv.lock` refresh and `pyproject-fmt` reformatting ride along.

## Test plan

- [x] `prek run --all-files` clean (pyproject-fmt, uv-lock hooks pass).
- [x] `uv sync --all-extras` resolves successfully with the pinned index.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
