### PR TITLE
feat: add get_little_group_of_pm_k helper

### DIFF
--- a/src/spgrep/symmetry/group.py
+++ b/src/spgrep/symmetry/group.py
@@ -150,6 +150,70 @@ def get_little_group(
     )
 
 
+def get_little_group_of_pm_k(
+    rotations: NDArrayInt,
+    translations: NDArrayFloat,
+    kpoint: NDArrayFloat,
+    atol: float = ATOL,
+) -> tuple[NDArrayInt, NDArrayFloat, NDArrayInt, NDArrayInt]:
+    r"""Return coset of little group of :math:`\pm \mathbf{k}`.
+
+    Returns operations that stabilize :math:`\{\mathbf{k}, -\mathbf{k}\}` as a
+    set (i.e. :math:`\mathbf{S}^{\top}\mathbf{k} \equiv \pm \mathbf{k}` mod
+    reciprocal lattice). See :ref:`pir_kbark`.
+
+    Parameters
+    ----------
+    rotations: array, (order, 3, 3)
+    translations: array, (order, 3)
+    kpoint: array, (3, )
+
+    Returns
+    -------
+    little_rotations: array, (little_group_order, 3, 3)
+    little_translations: array, (little_group_order, 3)
+    mapping_little_group: array, (little_group_order, )
+        ``(rotations[mapping_little_group[idx]], translations[mapping_little_group[idx]])``
+        belongs to the little group of :math:`\pm \mathbf{k}`.
+    flip_k: array[int], (little_group_order, )
+        ``flip_k[idx] == 0`` iff the ``idx``-th operation stabilizes
+        :math:`\mathbf{k}` itself. ``flip_k[idx] == 1`` iff it maps
+        :math:`\mathbf{k} \to -\mathbf{k}` (but not :math:`\mathbf{k}`).
+        When :math:`2\mathbf{k} \equiv \mathbf{0}` every stabilizing operation
+        counts as ``0``, so ``flip_k`` is all zeros and the output agrees with
+        :func:`get_little_group`.
+    """
+    little_rotations = []
+    little_translations = []
+    mapping_little_group = []
+    flip_k = []
+
+    for i, (rotation, translation) in enumerate(zip(rotations, translations)):
+        residual_plus = rotation.T @ kpoint - kpoint
+        residual_plus = residual_plus - np.rint(residual_plus)
+        stabilizes = np.allclose(residual_plus, 0, atol=atol)
+
+        residual_minus = rotation.T @ kpoint + kpoint
+        residual_minus = residual_minus - np.rint(residual_minus)
+        flips = np.allclose(residual_minus, 0, atol=atol)
+
+        if not (stabilizes or flips):
+            continue
+
+        little_rotations.append(rotation)
+        little_translations.append(translation)
+        mapping_little_group.append(i)
+        # If both hold (i.e. 2k equiv 0), treat as unitary (0).
+        flip_k.append(0 if stabilizes else 1)
+
+    return (
+        np.array(little_rotations),
+        np.array(little_translations),
+        np.array(mapping_little_group),
+        np.array(flip_k, dtype=np.int_),
+    )
+
+
 def check_cocycle_condition(
     rotations: NDArrayInt,
     factor_system: NDArrayComplex,

--- a/src/spgrep/symmetry/group.py
+++ b/src/spgrep/symmetry/group.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from spgrep._constants import ATOL
 from spgrep.utils import (
+    NDArrayBool,
     NDArrayComplex,
     NDArrayFloat,
     NDArrayInt,
@@ -155,7 +156,7 @@ def get_little_group_of_pm_k(
     translations: NDArrayFloat,
     kpoint: NDArrayFloat,
     atol: float = ATOL,
-) -> tuple[NDArrayInt, NDArrayFloat, NDArrayInt, NDArrayInt]:
+) -> tuple[NDArrayInt, NDArrayFloat, NDArrayInt, NDArrayBool]:
     r"""Return coset of little group of :math:`\pm \mathbf{k}`.
 
     Returns operations that stabilize :math:`\{\mathbf{k}, -\mathbf{k}\}` as a
@@ -175,13 +176,13 @@ def get_little_group_of_pm_k(
     mapping_little_group: array, (little_group_order, )
         ``(rotations[mapping_little_group[idx]], translations[mapping_little_group[idx]])``
         belongs to the little group of :math:`\pm \mathbf{k}`.
-    flip_k: array[int], (little_group_order, )
-        ``flip_k[idx] == 0`` iff the ``idx``-th operation stabilizes
-        :math:`\mathbf{k}` itself. ``flip_k[idx] == 1`` iff it maps
+    flip_k: array[bool], (little_group_order, )
+        ``flip_k[idx]`` is ``False`` iff the ``idx``-th operation stabilizes
+        :math:`\mathbf{k}` itself, and ``True`` iff it maps
         :math:`\mathbf{k} \to -\mathbf{k}` (but not :math:`\mathbf{k}`).
         When :math:`2\mathbf{k} \equiv \mathbf{0}` every stabilizing operation
-        counts as ``0``, so ``flip_k`` is all zeros and the output agrees with
-        :func:`get_little_group`.
+        counts as ``False``, so ``flip_k`` is all ``False`` and the output
+        agrees with :func:`get_little_group`.
     """
     little_rotations = []
     little_translations = []
@@ -203,14 +204,14 @@ def get_little_group_of_pm_k(
         little_rotations.append(rotation)
         little_translations.append(translation)
         mapping_little_group.append(i)
-        # If both hold (i.e. 2k equiv 0), treat as unitary (0).
-        flip_k.append(0 if stabilizes else 1)
+        # If both hold (i.e. 2k equiv 0), treat as unitary (False).
+        flip_k.append(not stabilizes)
 
     return (
         np.array(little_rotations),
         np.array(little_translations),
         np.array(mapping_little_group),
-        np.array(flip_k, dtype=np.int_),
+        np.array(flip_k, dtype=np.bool_),
     )
 
 

--- a/tests/symmetry/test_symmetry_group.py
+++ b/tests/symmetry/test_symmetry_group.py
@@ -52,7 +52,8 @@ def test_get_little_group_of_pm_k_coincides_with_little_group_when_2k_is_zero(P4
     np.testing.assert_allclose(pm_translations, little_translations)
     np.testing.assert_array_equal(pm_mapping, mapping_little_group)
     assert flip_k.shape == (len(little_rotations),)
-    assert np.all(flip_k == 0)
+    assert flip_k.dtype == np.bool_
+    assert not np.any(flip_k)
 
 
 def test_get_little_group_of_pm_k_on_pm3m_lambda():
@@ -71,15 +72,16 @@ def test_get_little_group_of_pm_k_on_pm3m_lambda():
     assert pm_translations.shape == (12, 3)
     assert pm_mapping.shape == (12,)
     assert flip_k.shape == (12,)
-    assert np.count_nonzero(flip_k == 0) == 6
-    assert np.count_nonzero(flip_k == 1) == 6
+    assert flip_k.dtype == np.bool_
+    assert np.count_nonzero(~flip_k) == 6
+    assert np.count_nonzero(flip_k) == 6
 
     # Stabilizing ops match get_little_group.
     little_rotations, _, _ = get_little_group(rotations, translations, kpoint)
-    np.testing.assert_array_equal(pm_rotations[flip_k == 0], little_rotations)
+    np.testing.assert_array_equal(pm_rotations[~flip_k], little_rotations)
 
     # k-flipping ops satisfy S^T k == -k (mod 1).
-    for rot in pm_rotations[flip_k == 1]:
+    for rot in pm_rotations[flip_k]:
         residual = rot.T @ kpoint + kpoint
         residual -= np.rint(residual)
         np.testing.assert_allclose(residual, 0, atol=1e-8)

--- a/tests/symmetry/test_symmetry_group.py
+++ b/tests/symmetry/test_symmetry_group.py
@@ -7,8 +7,10 @@ from spgrep.symmetry.group import (
     decompose_by_maximal_space_subgroup,
     get_factor_system_from_little_group,
     get_little_group,
+    get_little_group_of_pm_k,
     is_matrix_group,
 )
+from spgrep.utils import get_symmetry_from_hall_number
 
 
 def test_is_matrix_group(C3v):
@@ -32,6 +34,55 @@ def test_get_little_group_and_factor_system(P42mnm):
         little_rotations, little_translations, kpoint
     )
     assert check_cocycle_condition(little_rotations, factor_system)
+
+
+def test_get_little_group_of_pm_k_coincides_with_little_group_when_2k_is_zero(P42mnm):
+    # X = (0, 1/2, 0): 2k is a reciprocal lattice vector, so G^{k,k-bar} = G^k.
+    rotations, translations = P42mnm
+    kpoint = np.array([0, 1 / 2, 0])
+
+    little_rotations, little_translations, mapping_little_group = get_little_group(
+        rotations, translations, kpoint
+    )
+    pm_rotations, pm_translations, pm_mapping, flip_k = get_little_group_of_pm_k(
+        rotations, translations, kpoint
+    )
+
+    np.testing.assert_array_equal(pm_rotations, little_rotations)
+    np.testing.assert_allclose(pm_translations, little_translations)
+    np.testing.assert_array_equal(pm_mapping, mapping_little_group)
+    assert flip_k.shape == (len(little_rotations),)
+    assert np.all(flip_k == 0)
+
+
+def test_get_little_group_of_pm_k_on_pm3m_lambda():
+    # SG 221 (Pm-3m), Hall 517. Along Lambda k = (u, u, u) we have
+    # 2k = (2u, 2u, 2u) != 0 mod 1 for generic u, so G^{k,k-bar} strictly
+    # extends G^k. Little cogroup of k is D3 along [111] (order 6); little
+    # cogroup of {k, -k} is D3d (order 12) with the extra 6 ops mapping k
+    # to -k (see the Bilbao Lambda-line listing for Pm-3m).
+    rotations, translations = get_symmetry_from_hall_number(hall_number=517)
+    kpoint = np.array([1 / 4, 1 / 4, 1 / 4])
+
+    pm_rotations, pm_translations, pm_mapping, flip_k = get_little_group_of_pm_k(
+        rotations, translations, kpoint
+    )
+    assert pm_rotations.shape == (12, 3, 3)
+    assert pm_translations.shape == (12, 3)
+    assert pm_mapping.shape == (12,)
+    assert flip_k.shape == (12,)
+    assert np.count_nonzero(flip_k == 0) == 6
+    assert np.count_nonzero(flip_k == 1) == 6
+
+    # Stabilizing ops match get_little_group.
+    little_rotations, _, _ = get_little_group(rotations, translations, kpoint)
+    np.testing.assert_array_equal(pm_rotations[flip_k == 0], little_rotations)
+
+    # k-flipping ops satisfy S^T k == -k (mod 1).
+    for rot in pm_rotations[flip_k == 1]:
+        residual = rot.T @ kpoint + kpoint
+        residual -= np.rint(residual)
+        np.testing.assert_allclose(residual, 0, atol=1e-8)
 
 
 def test_decompose_by_maximal_space_subgroup(P42mnm_type3):


### PR DESCRIPTION
## Summary

- Add `spgrep.symmetry.group.get_little_group_of_pm_k(rotations, translations, kpoint)` returning the stabilizer of $\{\mathbf{k}, -\mathbf{k}\}$ as a set, together with a `flip_k` array that marks which operations map $\mathbf{k} \to -\mathbf{k}$ (as opposed to stabilizing $\mathbf{k}$ itself).
- When $2\mathbf{k} \equiv \mathbf{0}$ the output coincides with `get_little_group` and `flip_k` is all zeros, so this is a strict extension of the existing API.
- Motivation: this is the carrier on which the physically irreducible representation of a space group is defined (cross-reference `pir_kbark` in `docs/formulation/irreps/reality.md`). The helper lands ahead of the callers so it can be reviewed in isolation.

## Test plan

- [x] `uv run pytest tests/symmetry/test_symmetry_group.py -v` -- 5 passed.
  - `test_get_little_group_of_pm_k_coincides_with_little_group_when_2k_is_zero` (P4_2/mnm at X): output matches `get_little_group` member-for-member, `flip_k` all zero.
  - `test_get_little_group_of_pm_k_on_pm3m_lambda` (SG 221 Hall 517 at $\mathbf{k} = (1/4, 1/4, 1/4)$): 12 operations partitioned 6 stabilizing + 6 flipping, stabilizing subset matches `get_little_group`, every flipping op satisfies $\mathbf{S}^{\top}\mathbf{k} = -\mathbf{k}$ (mod 1).
- [x] `prek run --all-files` clean.

## Follow-ups

- PR consuming this helper in `enumerate_small_representations(real=True)` to fix the $2\mathbf{k} \not\equiv \mathbf{0}$ PIR output will stack on top of this branch.

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
