### PR TITLE
chore(deps): bump jupyterlab to 4.5.7 (CVE-2026-40171)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ optional-dependencies.dev = [
   "ipython",
   "matplotlib",
   "nbqa",
-  "notebook",
+  "notebook>=7.5.6",
   "phonopy",
   "prek",
   "seaborn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ urls.homepage = "https://github.com/spglib/spgrep"
 
 [tool.uv]
 exclude-newer = "1 week"
+# Override the cutoff for security patches that are newer than the window above.
+# CVE-2026-40171 (GHSA-rch3-82jr-f9w9): jupyterlab >= 4.5.7, notebook >= 7.5.6.
+exclude-newer-package = { jupyterlab = "2026-05-01", notebook = "2026-05-01" }
 
 [tool.ruff]
 line-length = 99

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-04-24T06:35:38.720594Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -3444,7 +3444,7 @@ requires-dist = [
     { name = "myst-parser", marker = "extra == 'docs'" },
     { name = "nbqa", marker = "extra == 'dev'" },
     { name = "nbsphinx", marker = "extra == 'docs'" },
-    { name = "notebook", marker = "extra == 'dev'" },
+    { name = "notebook", marker = "extra == 'dev'", specifier = ">=7.5.6" },
     { name = "numpy", specifier = ">=1.20.1" },
     { name = "phonopy", marker = "extra == 'dev'" },
     { name = "prek", marker = "extra == 'dev'" },

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,10 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
+[options.exclude-newer-package]
+notebook = "2026-05-01T15:00:00Z"
+jupyterlab = "2026-05-01T15:00:00Z"
+
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"
@@ -1355,7 +1359,7 @@ wheels = [
 
 [[package]]
 name = "jupyterlab"
-version = "4.5.6"
+version = "4.5.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-lru" },
@@ -1373,9 +1377,9 @@ dependencies = [
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/d5/730628e03fff2e8a8e8ccdaedde1489ab1309f9a4fa2536248884e30b7c7/jupyterlab-4.5.6.tar.gz", hash = "sha256:642fe2cfe7f0f5922a8a558ba7a0d246c7bc133b708dfe43f7b3a826d163cf42", size = 23970670, upload-time = "2026-03-11T14:17:04.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/22/8440ec827762146e7cdecf04335bd348795899d29dc6ae82238707353a2c/jupyterlab-4.5.7.tar.gz", hash = "sha256:55a9822c4754da305f41e113452c68383e214dcf96de760146af89ce5d5117b0", size = 23992763, upload-time = "2026-04-29T16:43:51.328Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/1b/dad6fdcc658ed7af26fdf3841e7394072c9549a8b896c381ab49dd11e2d9/jupyterlab-4.5.6-py3-none-any.whl", hash = "sha256:d6b3dac883aa4d9993348e0f8e95b24624f75099aed64eab6a4351a9cdd1e580", size = 12447124, upload-time = "2026-03-11T14:17:00.229Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/aa/537b8f7d80e799af19af35fb3ddfc970b951088a13c57dd9387dcfbb7f61/jupyterlab-4.5.7-py3-none-any.whl", hash = "sha256:fba4cb0e2c44a52859669d8c98b45de029d5e515f8407bf8534d2a8fc5f0964d", size = 12450123, upload-time = "2026-04-29T16:43:46.639Z" },
 ]
 
 [[package]]
@@ -1955,7 +1959,7 @@ wheels = [
 
 [[package]]
 name = "notebook"
-version = "7.5.5"
+version = "7.5.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-server" },
@@ -1964,9 +1968,9 @@ dependencies = [
     { name = "notebook-shim" },
     { name = "tornado" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/6d/41052c48d6f6349ca0a7c4d1f6a78464de135e6d18f5829ba2510e62184c/notebook-7.5.5.tar.gz", hash = "sha256:dc0bfab0f2372c8278c457423d3256c34154ac2cc76bf20e9925260c461013c3", size = 14169167, upload-time = "2026-03-11T16:32:51.922Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/c2/cf59bd2e6f2c8b976b52477e3e53bf6f97bc714ed046a51821afb428eaee/notebook-7.5.6.tar.gz", hash = "sha256:621174aade80108f0020b0f00738000b215f75fa3cd90771ad7aa0f24536a4e1", size = 14170814, upload-time = "2026-04-30T11:46:26.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/aa/cbd1deb9f07446241e88f8d5fecccd95b249bca0b4e5482214a4d1714c49/notebook-7.5.5-py3-none-any.whl", hash = "sha256:a7c14dbeefa6592e87f72290ca982e0c10f5bbf3786be2a600fda9da2764a2b8", size = 14578929, upload-time = "2026-03-11T16:32:48.021Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d6/1fd0646b9bbd9efbb0b8ae21b2325fbef515769a5621c03e31d8eb8da587/notebook-7.5.6-py3-none-any.whl", hash = "sha256:4dde3f8fb55fa8fb7946d58c6e869ce9baf46d00fc070664f62604569d0faca0", size = 14581730, upload-time = "2026-04-30T11:46:22.342Z" },
 ]
 
 [[package]]
@@ -2312,7 +2316,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- Patches Dependabot alert #11 (CVE-2026-40171 / GHSA-rch3-82jr-f9w9), a high-severity stored XSS in Jupyter Notebook's CommandLinker that enables auth-token theft.
- Bumps `jupyterlab` 4.5.6 -> 4.5.7 and `notebook` 7.5.5 -> 7.5.6 in `uv.lock`. Both are dev-only dependencies (notebook is direct, jupyterlab is transitive via notebook / nbsphinx).
- Pins `notebook>=7.5.6` directly in `[project.optional-dependencies.dev]` so future lock regenerations cannot drop back below the patched version.
- Adds an `[tool.uv].exclude-newer-package` override scoped to `jupyterlab` and `notebook` because the patched releases were published after the project's `exclude-newer = "1 week"` cutoff.

## Test plan
- [ ] CI matrix passes (Python 3.10/3.11/3.12/3.13)
- [ ] Docs build job passes
- [ ] `uv lock` is consistent (verified locally via `prek run uv-lock`)

[Claude Code] Generated with [Claude Code](https://claude.com/claude-code)
