### PR TITLE
Speed up point-subgroup traversal

### DIFF
--- a/src/spgrep/symmetry/subgroup.py
+++ b/src/spgrep/symmetry/subgroup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from queue import Queue
+from collections import deque
 
 from spgrep.rep.group import get_identity_index, get_inverse_index
 from spgrep.utils import (
@@ -79,7 +79,7 @@ def enumerate_point_subgroup_naive(table, preserve_sublattice: list[bool]):
     ret = []
     for bits in range(1, 1 << order):
         elements = _decode_bits(bits, order)
-        if not all([preserve_sublattice[idx] for idx in elements]):
+        if not all(preserve_sublattice[idx] for idx in elements):
             continue
 
         if _is_subgroup(elements, table):
@@ -108,18 +108,15 @@ def _traverse(
 ) -> list[int]:
     """Traverse group elements from generators."""
     visited = [False for _ in range(len(table))]
-    que = Queue()  # type: ignore
-    que.put(identity)
+    que = deque([identity])
+    visited[identity] = True
 
-    while not que.empty():
-        g = que.get()
-        if visited[g]:
-            continue
-        visited[g] = True
-
+    while que:
+        g = que.popleft()
         for h in generators:
             gh = int(table[g, h])  # cast np.int64 to int
             if not visited[gh]:
-                que.put(gh)
+                visited[gh] = True
+                que.append(gh)
 
     return sorted([i for i, v in enumerate(visited) if v])

--- a/tests/symmetry/test_symmetry_isotropy.py
+++ b/tests/symmetry/test_symmetry_isotropy.py
@@ -13,4 +13,5 @@ def test_enumerate_point_subgroup():
     flags = [True for _ in range(len(pointgroup))]
     subgroups_actual = enumerate_point_subgroup(table, flags, return_conjugacy_class=False)
     subgroups_expect = enumerate_point_subgroup_naive(table, flags)
-    assert len(subgroups_actual) == len(subgroups_expect)
+    subgroup_bits_actual = [sum(1 << idx for idx in subgroup) for subgroup in subgroups_actual]
+    assert subgroup_bits_actual == subgroups_expect


### PR DESCRIPTION
## Summary
- replace the thread-safe `Queue` in point-subgroup traversal with `collections.deque`
- mark group elements visited when enqueued to avoid duplicate traversal work while preserving result order
- compare the complete ordered subgroup result with brute-force enumeration in the regression test

Related: https://github.com/lan496/spinforge-dev/issues/193

## Test plan
- [x] `.venv/bin/python -m pytest -q` (136 passed, 1 skipped)
- [x] `tests/configuration_tests/test_oriented.py::test_noncoplanar_UO2_index4` against local spgrep
- [x] compare UO2 runtime with the old and new traversal (24.62 s -> 16.18 s)
- [x] commit-time formatter, Ruff, and mypy hooks on the changed files

## Notes
`prek run --all-files` still reports unrelated pre-existing Ruff findings elsewhere in the repository; the hooks for the files changed by this PR pass.
