### PR TITLE
Add v0.7.0 changelog and fix repository lint

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.7.0 (23 Aug. 2026)
+
+### Changed
+
+- Speed up point-subgroup enumeration by avoiding duplicate traversal work and replacing the thread-safe queue with `collections.deque`.
+
 ## v0.6.0 (27 Apr. 2026)
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [ "setuptools>=45", "setuptools-scm[toml]>=6.2", "wheel" ]
+requires = [ "setuptools>=45", "setuptools-scm[toml]>=6.2" ]
 
 [project]
 name = "spgrep"

--- a/src/spgrep/group.py
+++ b/src/spgrep/group.py
@@ -23,13 +23,13 @@ from spgrep.symmetry.group import (  # noqa: E402
 )
 
 __all__ = [
-    "get_identity_index",
-    "get_inverse_index",
-    "get_order",
-    "get_cayley_table",
-    "is_matrix_group",
-    "get_factor_system_from_little_group",
-    "get_little_group",
     "check_cocycle_condition",
     "decompose_by_maximal_space_subgroup",
+    "get_cayley_table",
+    "get_factor_system_from_little_group",
+    "get_identity_index",
+    "get_inverse_index",
+    "get_little_group",
+    "get_order",
+    "is_matrix_group",
 ]

--- a/src/spgrep/irreps.py
+++ b/src/spgrep/irreps.py
@@ -25,15 +25,12 @@ from spgrep.symmetry.enumerate import (  # noqa: E402
 from spgrep.symmetry.pir import purify_real_irrep_value  # noqa: E402
 
 __all__ = [
-    # spgrep.rep.enumerate
-    "enumerate_unitary_irreps_from_regular_representation",
     "decompose_representation",
-    # spgrep.rep.pir
-    "get_physically_irrep",
-    # spgrep.symmetry.enumerate
     "enumerate_small_representations",
     "enumerate_unitary_irreps",
+    "enumerate_unitary_irreps_from_regular_representation",
     "enumerate_unitary_irreps_from_solvable_group_chain",
+    "get_physically_irrep",
     "purify_irrep_value",
     "purify_real_irrep_value",
 ]

--- a/src/spgrep/pointgroup.py
+++ b/src/spgrep/pointgroup.py
@@ -17,8 +17,8 @@ from spgrep.symmetry.pointgroup import (  # noqa: E402
 )
 
 __all__ = [
-    "pg_dataset",
-    "pg_solvable_chain",
     "get_generators",
     "get_pointgroup_chain_generators",
+    "pg_dataset",
+    "pg_solvable_chain",
 ]

--- a/src/spgrep/rep/irreps.py
+++ b/src/spgrep/rep/irreps.py
@@ -153,10 +153,7 @@ def frobenius_schur_indicator(irrep: NDArrayComplex) -> int:
 def is_equivalent_irrep(character1: NDArrayComplex, character2: NDArrayComplex) -> bool:
     """Return true if two irreps are equivalent."""
     order = character1.shape[0]
-    if np.around(np.sum(np.conj(character1) * character2)) == order:
-        return True
-    else:
-        return False
+    return bool(np.around(np.sum(np.conj(character1) * character2)) == order)
 
 
 def is_unique_irreps(irreps: list[NDArrayComplex]):

--- a/src/spgrep/representation.py
+++ b/src/spgrep/representation.py
@@ -27,17 +27,14 @@ from spgrep.symmetry.representation import (  # noqa: E402
 )
 
 __all__ = [
-    # spgrep.rep.representation
-    "get_intertwiner",
-    "get_character",
-    "is_unitary",
-    "is_representation",
-    "get_direct_product",
-    # spgrep.symmetry.representation
-    "get_regular_representation",
-    "get_projective_regular_representation",
     "check_spacegroup_representation",
-    # spgrep.rep.irreps
-    "project_to_irrep",
     "frobenius_schur_indicator",
+    "get_character",
+    "get_direct_product",
+    "get_intertwiner",
+    "get_projective_regular_representation",
+    "get_regular_representation",
+    "is_representation",
+    "is_unitary",
+    "project_to_irrep",
 ]

--- a/src/spgrep/symmetry/enumerate.py
+++ b/src/spgrep/symmetry/enumerate.py
@@ -218,7 +218,7 @@ def enumerate_unitary_irreps_from_solvable_group_chain(
         group = []
         for m in range(p):
             group.extend([table[rm[m], s] for s in subgroup])
-        group = sorted(list(set(group)))
+        group = sorted(set(group))
 
         subgroup_remapping = {}  # GroupIdx -> int for `subgroup`
         for i, si in enumerate(subgroup):
@@ -309,7 +309,7 @@ def enumerate_unitary_irreps_from_solvable_group_chain(
         for sub_irrep in next_sub_irreps:
             # Skip duplicated irrep
             character = get_character(sub_irrep)
-            if any([is_equivalent_irrep(character, c) for c in sub_characters]):
+            if any(is_equivalent_irrep(character, c) for c in sub_characters):
                 continue
 
             irreps.append(sub_irrep)

--- a/src/spgrep/symmetry/group.py
+++ b/src/spgrep/symmetry/group.py
@@ -46,7 +46,7 @@ def get_cayley_table(
             trk = tri != trj
             k = operations_list.index((ndarray2d_to_integer_tuple(rk), trk))
             if table[i][j] != -1:
-                ValueError("Should specify a matrix group.")
+                raise ValueError("Should specify a matrix group.")
             table[i][j] = k
 
     return np.array(table)

--- a/src/spgrep/symmetry/pointgroup.py
+++ b/src/spgrep/symmetry/pointgroup.py
@@ -714,5 +714,4 @@ def get_pointgroup_chain_generators(prim_rotations: NDArrayInt) -> list[int]:
             generators = get_generators(pg_symbol, idx)
             return [mapping[g] for g in generators]
 
-    ValueError("Failed to match with tabulated point groups.")
-    return []  # This line is unreachable, just for persuading mypy!
+    raise ValueError("Failed to match with tabulated point groups.")

--- a/src/spgrep/symmetry/transform.py
+++ b/src/spgrep/symmetry/transform.py
@@ -186,7 +186,7 @@ def get_crystal_system(
     }
 
     for csystem, (lb, ub) in crystal_system_range.items():
-        if (lb <= hall_number) and (hall_number <= ub):
+        if lb <= hall_number <= ub:
             return csystem  # type: ignore
 
     raise ValueError(f"Unknown Hall number: {hall_number}")

--- a/src/spgrep/tensor.py
+++ b/src/spgrep/tensor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 
-from spgrep.symmetry.tensor import (  # noqa: #E402
+from spgrep.symmetry.tensor import (
     apply_intrinsic_symmetry,
     get_symmetry_adapted_tensors,
 )
@@ -14,6 +14,6 @@ warnings.warn(
 )
 
 __all__ = [
-    "get_symmetry_adapted_tensors",
     "apply_intrinsic_symmetry",
+    "get_symmetry_adapted_tensors",
 ]

--- a/src/spgrep/transform.py
+++ b/src/spgrep/transform.py
@@ -18,9 +18,9 @@ from spgrep.symmetry.transform import (  # noqa: E402
 )
 
 __all__ = [
+    "get_centering",
+    "get_crystal_system",
+    "get_primitive_transformation_matrix",
     "transform_symmetry_and_kpoint",
     "unique_primitive_symmetry",
-    "get_primitive_transformation_matrix",
-    "get_crystal_system",
-    "get_centering",
 ]

--- a/tests/symmetry/test_pointgroup.py
+++ b/tests/symmetry/test_pointgroup.py
@@ -6,7 +6,7 @@ from spgrep.symmetry.pointgroup import get_generators, pg_dataset
 
 
 def test_pg_dataset():
-    for _, groups in pg_dataset.items():
+    for groups in pg_dataset.values():
         for pg in groups:
             rotations = np.array(pg)
             assert is_matrix_group(rotations)
@@ -28,5 +28,5 @@ def test_group_chain():
                 # table[:gen, :gen] is normal subgroup
                 assert np.all(table[:gen, :gen] < gen)
                 for n in range(gen):
-                    assert all([table[inv[g], table[n, g]] < gen for g in range(prev_size)])
+                    assert all(table[inv[g], table[n, g]] < gen for g in range(prev_size))
                 prev_size = gen

--- a/tests/symmetry/test_symmetry_enumerate.py
+++ b/tests/symmetry/test_symmetry_enumerate.py
@@ -125,7 +125,7 @@ def test_small_representation_with_origin_shift(hall_number, kpoint, method, ori
 
 
 def test_frobenius_schur_indicator(C4):
-    irreps, indicators = enumerate_unitary_irreps(C4)
+    _, indicators = enumerate_unitary_irreps(C4)
     assert sorted(indicators) == [0, 0, 1, 1]
 
 

--- a/tests/symmetry/test_symmetry_pir.py
+++ b/tests/symmetry/test_symmetry_pir.py
@@ -108,7 +108,7 @@ def test_spacegroup_pir_pm3m_lambda():
     u = 0.1  # generic Lambda point; 2u is not integer so 2k is not equivalent to 0
     kpoint = np.array([u, u, u])
 
-    pm_k_rotations, _, mapping_little_group, flip_k = get_little_group_of_pm_k(
+    pm_k_rotations, _, _mapping_little_group, flip_k = get_little_group_of_pm_k(
         rotations, translations, kpoint
     )
     # little cogroup of +/- k for Lambda in Pm-3m is D3d (order 12),

--- a/tests/test_corep.py
+++ b/tests/test_corep.py
@@ -78,7 +78,7 @@ def check_corep_cocycle_condition(
 def test_corep_spinor_factor_system(request, symmetry_and_lattice):
     rotations, _, time_reversals, lattice = request.getfixturevalue(symmetry_and_lattice)
 
-    corep_spinor_factor_system, unitary_rotations, anti_linear = get_corep_spinor_factor_system(
+    corep_spinor_factor_system, unitary_rotations, _anti_linear = get_corep_spinor_factor_system(
         lattice, rotations, time_reversals
     )
 
@@ -111,9 +111,9 @@ def test_get_crystallographic_pointgroup_spinor_irreps_from_symmetry(
     # TODO: Add more tests
     (
         co_irreps,
-        indicators,
+        _indicators,
         factor_system,
-        unitary_rotations,
+        _unitary_rotations,
         anti_linear,
     ) = get_crystallographic_pointgroup_spinor_irreps_from_symmetry(
         lattice,
@@ -149,15 +149,15 @@ def test_get_crystallographic_pointgroup_spinor_irreps_from_symmetry(
 def test_get_magnetic_spacegroup_coreps_from_primitive_symmetry(
     request, kpoint: NDArrayFloat, method, symmetry_and_lattice
 ):
-    rotations, translations, time_reversals, lattice = request.getfixturevalue(
+    rotations, translations, time_reversals, _lattice = request.getfixturevalue(
         symmetry_and_lattice
     )
 
     # TODO: Add more tests
     (
-        co_irreps,
-        anti_linear,
-        mapping_little_group,
+        _co_irreps,
+        _anti_linear,
+        _mapping_little_group,
     ) = get_magnetic_spacegroup_coreps_from_primitive_symmetry(
         rotations=rotations,
         translations=translations,

--- a/tests/test_spinor.py
+++ b/tests/test_spinor.py
@@ -88,11 +88,11 @@ def test_spinor_irreps(method, C3v, hexagonal_lattice):
 def test_get_spacegroup_spinor_irreps(kpoint, shape_expect, corundum_cell):
     (
         irreps,
-        little_spinor_factor_system,
-        little_unitary_rotations,
-        rotations,
-        translations,
-        mapping,
+        _little_spinor_factor_system,
+        _little_unitary_rotations,
+        _rotations,
+        _translations,
+        _mapping,
     ) = get_spacegroup_spinor_irreps(
         *corundum_cell,
         kpoint=kpoint,
@@ -114,7 +114,7 @@ def test_get_spacegroup_spinor_irreps_from_primitive_symmetry(kpoint, shape_expe
         irreps,
         little_spinor_factor_system,
         little_unitary_rotations,
-        mapping_little_group,
+        _mapping_little_group,
     ) = get_spacegroup_spinor_irreps_from_primitive_symmetry(
         lattice=np.eye(3),
         rotations=rotations,

--- a/uv.lock
+++ b/uv.lock
@@ -19,8 +19,8 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-notebook = "2026-05-02T00:00:00Z"
-jupyterlab = "2026-05-02T00:00:00Z"
+notebook = "2026-05-01T15:00:00Z"
+jupyterlab = "2026-05-01T15:00:00Z"
 
 [[package]]
 name = "accessible-pygments"


### PR DESCRIPTION
## Summary
- add the v0.7.0 changelog entry for the point-subgroup enumeration speedup
- resolve repository-wide Ruff findings, including restoring the intended error raises
- apply the current project and lockfile formatter output

## Test plan
- [x] `prek run --all-files`
- [x] `.venv/bin/pytest -q` (136 passed, 1 skipped)
