### PR TITLE
Fix Renovate digest update automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -49,7 +49,7 @@
     {
       "description": "Automerge CI and devDependencies non-major updates",
       "matchManagers": ["github-actions", "pre-commit"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true,
       "platformAutomerge": true
     },


### PR DESCRIPTION
## Summary

- Include digest updates in the non-major automerge rule for GitHub Actions and pre-commit dependencies.
- Keep grouped CI dependency PRs eligible for automerge when they contain pinned GitHub Action digest updates.

## Test plan

- [x] `npx --yes --package renovate renovate-config-validator .github/renovate.json5`
- [x] `SKIP=uv-lock prek run --all-files` (the current uv-lock hook rewrites unrelated `exclude-newer` timestamps)
- [x] `uv run --extra testing pytest -v` (136 passed, 1 skipped)
